### PR TITLE
Fixed the command line error so that -p4 argument is working again

### DIFF
--- a/src/VirtualMonitor/VNCDisplay.cpp
+++ b/src/VirtualMonitor/VNCDisplay.cpp
@@ -92,7 +92,7 @@ int VNCDisplay::Init(DisplayParam &param, char *pVideoMemory)
         }
 
     }
-    if (ipv4Port == 0 || ipv6Port == 0)
+    if (ipv4Port == 0 && ipv6Port == 0)
         vncServer->autoPort = 1;
     else
     {


### PR DESCRIPTION
currently "virtualmonitor.exe -p4 5901" option is not working. The reason is because of incorrect condition check vncServer->autoPort is reinitialized to 1 again. It should only be so when both ipv4Port and ipv6Port are zero
